### PR TITLE
feat: compress support

### DIFF
--- a/opengemini-client-api/src/main/java/io/opengemini/client/api/CompressMethod.java
+++ b/opengemini-client-api/src/main/java/io/opengemini/client/api/CompressMethod.java
@@ -16,33 +16,18 @@
 
 package io.opengemini.client.api;
 
-import io.github.openfacade.http.HttpClientConfig;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+public enum CompressMethod {
+    GZIP("gzip"),
+    SNAPPY("snappy"),
+    ZSTD("zstd");
 
-import java.util.List;
+    private final String value;
 
-@Setter
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Configuration {
-    List<Address> addresses;
+    CompressMethod(String value) {
+        this.value = value;
+    }
 
-    AuthConfig authConfig;
-
-    BatchConfig batchConfig;
-
-    ContentType contentType;
-
-    CompressMethod compressMethod;
-
-   // deprecated, will use compressMethod and contentType
-    boolean gzipEnabled;
-
-    HttpClientConfig httpConfig;
+    public String getValue() {
+        return value;
+    }
 }

--- a/opengemini-client-api/src/main/java/io/opengemini/client/api/ContentType.java
+++ b/opengemini-client-api/src/main/java/io/opengemini/client/api/ContentType.java
@@ -16,33 +16,17 @@
 
 package io.opengemini.client.api;
 
-import io.github.openfacade.http.HttpClientConfig;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+public enum ContentType {
+    JSON("application/json"),
+    MSGPACK("application/msgpack");
 
-import java.util.List;
+    private final String value;
 
-@Setter
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Configuration {
-    List<Address> addresses;
+    ContentType(String value) {
+        this.value = value;
+    }
 
-    AuthConfig authConfig;
-
-    BatchConfig batchConfig;
-
-    ContentType contentType;
-
-    CompressMethod compressMethod;
-
-   // deprecated, will use compressMethod and contentType
-    boolean gzipEnabled;
-
-    HttpClientConfig httpConfig;
+    public String getValue() {
+        return value;
+    }
 }

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/BaseClient.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/BaseClient.java
@@ -55,6 +55,9 @@ public abstract class BaseClient implements Closeable {
             contentEncodingHeader.add("gzip");
             headers.put("Content-Encoding", contentEncodingHeader);
         }
+
+        applyCodec(conf, headers);
+
         String httpPrefix;
         if (conf.getHttpConfig().tlsConfig() != null) {
             httpPrefix = "https://";
@@ -75,6 +78,36 @@ public abstract class BaseClient implements Closeable {
             this.scheduler = Optional.empty();
         }
         scheduler.ifPresent(this::startHealthCheck);
+    }
+
+    private void applyCodec(Configuration config, Map<String, List<String>> headers) {
+        if (config.getContentType() != null) {
+            List<String> acceptHeader = new ArrayList<>();
+            switch (config.getContentType()) {
+                case MSGPACK:
+                    acceptHeader.add("application/msgpack");
+                    break;
+                case JSON:
+                    acceptHeader.add("application/json");
+                    break;
+            }
+        headers.put("Accept", acceptHeader);
+        }
+        if (config.getCompressMethod() != null) {
+            List<String> acceptEncodingHeader = new ArrayList<>();
+            switch (config.getCompressMethod()) {
+                case GZIP:
+                    acceptEncodingHeader.add("gzip");
+                    break;
+                case ZSTD:
+                    acceptEncodingHeader.add("zstd");
+                    break;
+                case SNAPPY:
+                    acceptEncodingHeader.add("snappy");
+                    break;
+            }
+            headers.put("Accept-Encoding", acceptEncodingHeader);
+        }
     }
 
     /**

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/Compressor.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/Compressor.java
@@ -14,35 +14,13 @@
  * limitations under the License.
  */
 
-package io.opengemini.client.api;
+package io.opengemini.client.common.compress;
 
-import io.github.openfacade.http.HttpClientConfig;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+public interface Compressor {
 
-import java.util.List;
+        byte[] compress(byte[] data);
 
-@Setter
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Configuration {
-    List<Address> addresses;
+        byte[] decompress(byte[] data);
 
-    AuthConfig authConfig;
-
-    BatchConfig batchConfig;
-
-    ContentType contentType;
-
-    CompressMethod compressMethod;
-
-   // deprecated, will use compressMethod and contentType
-    boolean gzipEnabled;
-
-    HttpClientConfig httpConfig;
+        String getName();
 }

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/GzipCompressor.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/GzipCompressor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import io.opengemini.client.api.CompressMethod;
+import lombok.AllArgsConstructor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+@AllArgsConstructor
+public class GzipCompressor implements Compressor {
+
+    @Override
+    public byte[] compress(byte[] data) {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+             GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+            gzipOutputStream.write(data);
+            gzipOutputStream.finish();
+            return byteArrayOutputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to compress data", e);
+        }
+    }
+
+    @Override
+    public byte[] decompress(byte[] data) {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(data);
+             GZIPInputStream gzipInputStream = new GZIPInputStream(byteArrayInputStream);
+             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzipInputStream.read(buffer)) != -1) {
+                byteArrayOutputStream.write(buffer, 0, len);
+            }
+            return byteArrayOutputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to decompress data", e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return CompressMethod.GZIP.getValue();
+    }
+}

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/SnappyCompressor.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/SnappyCompressor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import io.opengemini.client.api.CompressMethod;
+import lombok.AllArgsConstructor;
+import org.xerial.snappy.Snappy;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class SnappyCompressor implements Compressor {
+
+    @Override
+    public byte[] compress(byte[] data) {
+        try {
+            return Snappy.compress(data);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to compress data", e);
+        }
+    }
+
+    @Override
+    public byte[] decompress(byte[] data) {
+        try {
+            return Snappy.uncompress(data);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to decompress data", e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return CompressMethod.SNAPPY.getValue();
+    }
+}

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/ZstdCompressor.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/ZstdCompressor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import com.github.luben.zstd.Zstd;
+import io.opengemini.client.api.CompressMethod;
+
+public class ZstdCompressor implements Compressor {
+
+    @Override
+    public byte[] compress(byte[] data) {
+        return Zstd.compress(data);
+    }
+
+    @Override
+    public byte[] decompress(byte[] data) {
+        try {
+            long decompressedSize = Zstd.decompressedSize(data);
+            byte[] decompressedData = new byte[(int) decompressedSize];
+            Zstd.decompress(decompressedData, data);
+            return decompressedData;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to decompress data", e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return CompressMethod.ZSTD.getValue();
+    }
+}

--- a/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/package-info.java
+++ b/opengemini-client-common/src/main/java/io/opengemini/client/common/compress/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;

--- a/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/GzipCompressorTest.java
+++ b/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/GzipCompressorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GzipCompressorTest {
+
+    private final GzipCompressor gzipCompressor = new GzipCompressor();
+
+    @Test
+    void testCompressAndDecompress() {
+        String originalString = "This is a test string for GZIP compression";
+        byte[] originalData = originalString.getBytes();
+
+        // Compress the data
+        byte[] compressedData = gzipCompressor.compress(originalData);
+        Assertions.assertNotNull(compressedData);
+        Assertions.assertNotEquals(0, compressedData.length);
+
+        // Decompress the data
+        byte[] decompressedData = gzipCompressor.decompress(compressedData);
+        Assertions.assertNotNull(decompressedData);
+        Assertions.assertArrayEquals(originalData, decompressedData);
+
+        // Verify the decompressed string is the same as the original
+        String decompressedString = new String(decompressedData);
+        Assertions.assertEquals(originalString, decompressedString);
+    }
+}

--- a/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/SnappyCompressorTest.java
+++ b/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/SnappyCompressorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SnappyCompressorTest {
+    @Test
+    public void testCompression() {
+        SnappyCompressor snappyCompressor = new SnappyCompressor();
+        // Example input data
+        String input = "This is a test string to compress";
+        byte[] inputData = input.getBytes();
+
+        // Compress the data
+        byte[] compressedData = snappyCompressor.compress(inputData);
+
+        // Decompress the data
+        byte[] decompressedData = snappyCompressor.decompress(compressedData);
+
+        // Verify the decompressed data matches the original input
+        Assertions.assertArrayEquals(inputData, decompressedData);
+    }
+}

--- a/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/ZstdCompressorTest.java
+++ b/opengemini-client-common/src/test/java/io/opengemini/client/common/compress/ZstdCompressorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.common.compress;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ZstdCompressorTest {
+
+    @Test
+    public void testCompression() {
+        ZstdCompressor zstdCompressor = new ZstdCompressor();
+        // Example input data
+        String input = "This is a test string to compress";
+        byte[] inputData = input.getBytes();
+
+        // Compress the data
+        byte[] compressedData = zstdCompressor.compress(inputData);
+
+        // Decompress the data
+        byte[] decompressedData = zstdCompressor.decompress(compressedData);
+
+        // Verify the decompressed data matches the original input
+        Assertions.assertArrayEquals(inputData, decompressedData);
+    }
+}

--- a/opengemini-client/src/main/java/io/opengemini/client/impl/OpenGeminiClient.java
+++ b/opengemini-client/src/main/java/io/opengemini/client/impl/OpenGeminiClient.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.opengemini.client.impl;
 
 import io.github.openfacade.http.BasicAuthRequestFilter;
@@ -46,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class OpenGeminiClient extends BaseAsyncClient {
+
     protected final Configuration conf;
 
     private final HttpClient client;
@@ -88,9 +88,9 @@ public class OpenGeminiClient extends BaseAsyncClient {
     /**
      * Execute a write call with java HttpClient.
      *
-     * @param database        the name of the database.
+     * @param database the name of the database.
      * @param retentionPolicy the name of the retention policy.
-     * @param lineProtocol    the line protocol string to write.
+     * @param lineProtocol the line protocol string to write.
      */
     @Override
     protected CompletableFuture<Void> executeWrite(String database, String retentionPolicy, String lineProtocol) {
@@ -109,7 +109,8 @@ public class OpenGeminiClient extends BaseAsyncClient {
                 .orElse(null)).thenApply(Pong::new);
     }
 
-    private @NotNull <T> CompletableFuture<T> convertResponse(HttpResponse response, Class<T> type) {
+    private @NotNull
+    <T> CompletableFuture<T> convertResponse(HttpResponse response, Class<T> type) {
         if (response.statusCode() >= 200 && response.statusCode() < 300) {
             try {
                 T resp = processResponseBody(response, type);
@@ -136,26 +137,32 @@ public class OpenGeminiClient extends BaseAsyncClient {
                 ? response.headers().get("Content-Encoding").get(0) : null;
         byte[] body = processCompression(contentEncoding, response.body(), type);
 
-       return processContentType(contentType, body, type);
+        return processContentType(contentType, body, type);
     }
 
     private <T> byte[] processCompression(String compressMethod, byte[] body, Class<T> type) throws IOException {
         byte[] decompressedBody = null;
         if (CompressMethod.GZIP.getValue().equals(compressMethod)) {
-            GzipCompressor compressor = (GzipCompressor) compressorCache.computeIfAbsent(CompressMethod.GZIP.getValue(), k -> new GzipCompressor());
+            GzipCompressor compressor = (GzipCompressor) compressorCache.computeIfAbsent(
+                    CompressMethod.GZIP.getValue(),
+                    k -> new GzipCompressor());
             decompressedBody = compressor.decompress(body);
         } else if (CompressMethod.SNAPPY.getValue().equals(compressMethod)) {
-            SnappyCompressor compressor = (SnappyCompressor) compressorCache.computeIfAbsent(CompressMethod.SNAPPY.getValue(), k -> new SnappyCompressor());
+            SnappyCompressor compressor = (SnappyCompressor) compressorCache.computeIfAbsent(
+                    CompressMethod.SNAPPY.getValue(),
+                    k -> new SnappyCompressor());
             decompressedBody = compressor.decompress(body);
         } else if (CompressMethod.ZSTD.getValue().equals(compressMethod)) {
-            ZstdCompressor compressor = (ZstdCompressor) compressorCache.computeIfAbsent(CompressMethod.ZSTD.getValue(), k -> new ZstdCompressor());
+            ZstdCompressor compressor = (ZstdCompressor) compressorCache.computeIfAbsent(
+                    CompressMethod.ZSTD.getValue(),
+                    k -> new ZstdCompressor());
             decompressedBody = compressor.decompress(body);
         }
 
         return decompressedBody != null ? decompressedBody : body;
     }
 
-    private <T> T processContentType(String contentType, byte[] body,  Class<T> type) throws IOException {
+    private <T> T processContentType(String contentType, byte[] body, Class<T> type) throws IOException {
         if (ContentType.JSON.getValue().equals(contentType)) {
             return JacksonService.toObject(body, type);
         } else if (ContentType.MSGPACK.getValue().equals(contentType)) {
@@ -170,7 +177,7 @@ public class OpenGeminiClient extends BaseAsyncClient {
 
     public CompletableFuture<HttpResponse> post(String url, String body) {
         return client.post(buildUriWithPrefix(url), body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8),
-                           headers);
+                headers);
     }
 
     @Override

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientTest.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.opengemini.client.impl;
 
 import io.github.openfacade.http.HttpClientConfig;
@@ -54,6 +53,7 @@ import java.util.concurrent.ExecutionException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenGeminiClientTest extends TestBase {
+
     private final List<OpenGeminiClient> clients = new ArrayList<>();
 
     protected List<OpenGeminiClient> clientList() throws OpenGeminiException {
@@ -69,19 +69,19 @@ class OpenGeminiClientTest extends TestBase {
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();
-            Configuration configuration =
-                Configuration.builder()
-                             .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
-                             .httpConfig(httpConfig)
-                             .gzipEnabled(false)
-                             .build();
+            Configuration configuration
+                    = Configuration.builder()
+                            .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                            .httpConfig(httpConfig)
+                            .gzipEnabled(false)
+                            .build();
             clients.add(OpenGeminiClientFactory.create(configuration));
         }
         List<CompressMethod> compressMethods = Arrays.asList(CompressMethod.SNAPPY, CompressMethod.GZIP,
                 CompressMethod.ZSTD);
         for (CompressMethod compressMethod : compressMethods) {
             HttpClientConfig httpConfig = new HttpClientConfig.Builder()
-                    .engine(HttpClientEngine.AsyncHttpClient)
+                    .engine(HttpClientEngine.Async)
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientTest.java
@@ -69,12 +69,12 @@ class OpenGeminiClientTest extends TestBase {
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();
-            Configuration configuration
-                    = Configuration.builder()
-                            .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
-                            .httpConfig(httpConfig)
-                            .gzipEnabled(false)
-                            .build();
+            Configuration configuration = Configuration
+                    .builder()
+                    .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                    .httpConfig(httpConfig)
+                    .gzipEnabled(false)
+                    .build();
             clients.add(OpenGeminiClientFactory.create(configuration));
         }
         List<CompressMethod> compressMethods = Arrays.asList(CompressMethod.SNAPPY, CompressMethod.GZIP,

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
@@ -59,12 +59,11 @@ class OpenGeminiClientWriteTest extends TestBase {
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();
-            Configuration configuration
-                    = Configuration.builder()
-                            .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
-                            .httpConfig(httpConfig)
-                            .gzipEnabled(false)
-                            .build();
+            Configuration configuration = Configuration.builder()
+                    .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                    .httpConfig(httpConfig)
+                    .gzipEnabled(false)
+                    .build();
             clients.add(OpenGeminiClientFactory.create(configuration));
         }
 

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
@@ -13,8 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.opengemini.client.impl;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.openfacade.http.HttpClientConfig;
 import io.github.openfacade.http.HttpClientEngine;
@@ -27,23 +41,10 @@ import io.opengemini.client.api.Query;
 import io.opengemini.client.api.QueryResult;
 import io.opengemini.client.api.RpConfig;
 import io.opengemini.client.api.Series;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenGeminiClientWriteTest extends TestBase {
+
     private final List<OpenGeminiClient> clients = new ArrayList<>();
 
     protected List<OpenGeminiClient> clientList() throws OpenGeminiException {
@@ -59,19 +60,19 @@ class OpenGeminiClientWriteTest extends TestBase {
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();
-            Configuration configuration =
-                Configuration.builder()
-                             .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
-                             .httpConfig(httpConfig)
-                             .gzipEnabled(false)
-                             .build();
+            Configuration configuration
+                    = Configuration.builder()
+                            .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                            .httpConfig(httpConfig)
+                            .gzipEnabled(false)
+                            .build();
             clients.add(OpenGeminiClientFactory.create(configuration));
         }
 
         List<CompressMethod> compressMethods = Arrays.asList(CompressMethod.SNAPPY);
         for (CompressMethod compressMethod : compressMethods) {
             HttpClientConfig httpConfig = new HttpClientConfig.Builder()
-                    .engine(HttpClientEngine.AsyncHttpClient)
+                    .engine(HttpClientEngine.Java)
                     .connectTimeout(Duration.ofSeconds(3))
                     .timeout(Duration.ofSeconds(3))
                     .build();

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
@@ -19,6 +19,7 @@ package io.opengemini.client.impl;
 import io.github.openfacade.http.HttpClientConfig;
 import io.github.openfacade.http.HttpClientEngine;
 import io.opengemini.client.api.Address;
+import io.opengemini.client.api.CompressMethod;
 import io.opengemini.client.api.Configuration;
 import io.opengemini.client.api.OpenGeminiException;
 import io.opengemini.client.api.Point;
@@ -66,6 +67,21 @@ class OpenGeminiClientWriteTest extends TestBase {
                              .build();
             clients.add(OpenGeminiClientFactory.create(configuration));
         }
+
+        List<CompressMethod> compressMethods = Arrays.asList(CompressMethod.SNAPPY);
+        for (CompressMethod compressMethod : compressMethods) {
+            HttpClientConfig httpConfig = new HttpClientConfig.Builder()
+                    .engine(HttpClientEngine.AsyncHttpClient)
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .timeout(Duration.ofSeconds(3))
+                    .build();
+            Configuration configuration = Configuration.builder()
+                    .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                    .httpConfig(httpConfig)
+                    .compressMethod(compressMethod)
+                    .build();
+            clients.add(OpenGeminiClientFactory.create(configuration));
+        }
         return clients;
     }
 
@@ -111,7 +127,8 @@ class OpenGeminiClientWriteTest extends TestBase {
         writeRsp.get();
         Thread.sleep(3000);
 
-        Query selectQuery = new Query("select * from " + measurementName, databaseName, "");
+        Query selectQuery = new Query("select * from " + measurementName,
+                databaseName, "");
         CompletableFuture<QueryResult> rst = client.query(selectQuery);
         QueryResult queryResult = rst.get();
 

--- a/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/impl/OpenGeminiClientWriteTest.java
@@ -15,21 +15,6 @@
  */
 package io.opengemini.client.impl;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import io.github.openfacade.http.HttpClientConfig;
 import io.github.openfacade.http.HttpClientEngine;
 import io.opengemini.client.api.Address;
@@ -41,6 +26,20 @@ import io.opengemini.client.api.Query;
 import io.opengemini.client.api.QueryResult;
 import io.opengemini.client.api.RpConfig;
 import io.opengemini.client.api.Series;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenGeminiClientWriteTest extends TestBase {

--- a/spring/opengemini-spring/src/main/java/io/opengemini/client/spring/data/core/OpenGeminiTemplate.java
+++ b/spring/opengemini-spring/src/main/java/io/opengemini/client/spring/data/core/OpenGeminiTemplate.java
@@ -120,7 +120,7 @@ public class OpenGeminiTemplate implements OpenGeminiOperations {
     }
 
     @SuppressWarnings("unchecked")
-    private @NotNull <T> MeasurementOperations<T> getMeasurementOperations(MeasurementOperationsCacheKey key) {
+    private  @NotNull <T> MeasurementOperations<T> getMeasurementOperations(MeasurementOperationsCacheKey key) {
         return (MeasurementOperations<T>) msOperationsMap.computeIfAbsent(key, (k) -> {
             OpenGeminiSerializer<T> serializer = (OpenGeminiSerializer<T>) serializerFactory.getSerializer(
                     k.getClazz());


### PR DESCRIPTION
### Description 
 this PR is adding the compression support.

### Changes 
1. add enum for compression method and content type
2. add apply logic for modifying the http header before REST call, and process the response body according the http header config
3.  related tests


### Validation
![image](https://github.com/user-attachments/assets/25b31e7b-2858-4c26-ba12-5f07ad064538)




### TodoList

1. [x]  How should the changes for configuration be rolled out? For example, deprecate `isGzipEnabled`.

