### PR TITLE
feat: support otel for sdk

### DIFF
--- a/opengemini-client-api/src/main/java/io/opengemini/client/api/Write.java
+++ b/opengemini-client-api/src/main/java/io/opengemini/client/api/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 openGemini Authors
+ * Copyright 2025 openGemini Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,53 +16,26 @@
 
 package io.opengemini.client.api;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@AllArgsConstructor
 @Getter
 @Setter
-public class Query {
-    /*
-     * the query command
-     */
-    private String command;
-
-    /*
-     * the database name of the query command using
-     */
+public class Write {
     private String database;
-
-    /*
-     * the rp name of the query command using
-     */
     private String retentionPolicy;
-
-    /*
-     * the precision of the time in query result
-     */
-    private Precision precision;
+    private String lineProtocol;
+    private String precision;
 
     private Map<String, Object> attributes = new HashMap<>();
 
-    public Query(String command) {
-        this.command = command;
-    }
-
-    public Query(String command, String database, String retentionPolicy) {
-        this.command = command;
+    public Write(String database, String retentionPolicy, String lineProtocol, String precision) {
         this.database = database;
         this.retentionPolicy = retentionPolicy;
-    }
-
-    public Query(String command, String database, String retentionPolicy, Precision precision) {
-        this.command = command;
-        this.database = database;
-        this.retentionPolicy = retentionPolicy;
+        this.lineProtocol = lineProtocol;
         this.precision = precision;
     }
 

--- a/opengemini-client/src/main/java/io/opengemini/client/impl/OpenTelemetryConfig.java
+++ b/opengemini-client/src/main/java/io/opengemini/client/impl/OpenTelemetryConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.impl;
+
+import io.opentelemetry.api.trace.Tracer;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configuration for OpenTelemetry tracing.
+ */
+@Getter
+@Setter
+public class OpenTelemetryConfig {
+    private volatile Tracer tracer;
+}

--- a/opengemini-client/src/main/java/io/opengemini/client/interceptor/Interceptor.java
+++ b/opengemini-client/src/main/java/io/opengemini/client/interceptor/Interceptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.interceptor;
+
+import io.github.openfacade.http.HttpResponse;
+import io.opengemini.client.api.Query;
+import io.opengemini.client.api.Write;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interceptor interface for OpenGemini client operations.
+ * Allows custom logic to be executed before and after query and write operations.
+ */
+public interface Interceptor {
+
+    /**
+     * Executes before a query operation.
+     *
+     * @param query the query to be executed
+     * @return a CompletableFuture that completes when the interceptor logic is done
+     */
+    CompletableFuture<Void> queryBefore(Query query);
+
+    /**
+     * Executes after a query operation.
+     *
+     * @param query the query that was executed
+     * @param response the HTTP response from the query
+     * @return a CompletableFuture that completes when the interceptor logic is done
+     */
+    CompletableFuture<Void> queryAfter(Query query, HttpResponse response);
+
+    /**
+     * Executes before a write operation.
+     *
+     * @param write the write operation to be executed
+     * @return a CompletableFuture that completes when the interceptor logic is done
+     */
+    CompletableFuture<Void> writeBefore(Write write);
+
+    /**
+     * Executes after a write operation.
+     *
+     * @param write the write operation that was executed
+     * @param response the HTTP response from the write
+     * @return a CompletableFuture that completes when the interceptor logic is done
+     */
+    CompletableFuture<Void> writeAfter(Write write, HttpResponse response);
+}

--- a/opengemini-client/src/main/java/io/opengemini/client/interceptor/OtelInterceptor.java
+++ b/opengemini-client/src/main/java/io/opengemini/client/interceptor/OtelInterceptor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.interceptor;
+
+import io.github.openfacade.http.HttpResponse;
+import io.opengemini.client.api.Query;
+import io.opengemini.client.api.Write;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.concurrent.CompletableFuture;
+
+@Getter
+@Setter
+public class OtelInterceptor implements Interceptor {
+    private io.opentelemetry.api.trace.Tracer tracer;
+
+    @Override
+    public CompletableFuture<Void> queryBefore(Query query) {
+        return CompletableFuture.runAsync(() -> {
+            Span querySpan = tracer.spanBuilder("query")
+                    .setSpanKind(SpanKind.CLIENT)
+                    .setAttribute("database", query.getDatabase() != null ? query.getDatabase() : "unknown")
+                    .setAttribute("command", query.getCommand())
+                    .startSpan();
+
+            query.setAttribute("querySpan", querySpan);
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> queryAfter(Query query, HttpResponse response) {
+        return CompletableFuture.runAsync(() -> {
+            Span querySpan = (Span) query.getAttribute("querySpan");
+            if (querySpan == null) {
+                return;
+            }
+
+            int statusCode = response.statusCode();
+            querySpan.setAttribute("status_code", statusCode);
+            if (statusCode >= 400) {
+                String errorBody = response.bodyAsString();
+                querySpan.setStatus(StatusCode.ERROR, "HTTP error: " + statusCode);
+                querySpan.setAttribute("error.message", errorBody);
+            } else {
+                querySpan.setStatus(StatusCode.OK);
+            }
+            querySpan.end();
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> writeBefore(Write write) {
+        return CompletableFuture.runAsync(() -> {
+            Span writeSpan = tracer.spanBuilder("write")
+                    .setSpanKind(SpanKind.CLIENT)
+                    .setAttribute("database", write.getDatabase())
+                    .setAttribute("retention_policy", write.getRetentionPolicy())
+                    .setAttribute("command", write.getLineProtocol())
+                    .startSpan();
+            write.setAttribute("writeSpan", writeSpan);
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> writeAfter(Write write, HttpResponse response) {
+        return CompletableFuture.runAsync(() -> {
+            Span writeSpan = (Span) write.getAttribute("writeSpan");
+            if (writeSpan == null) {
+                return;
+            }
+            int statusCode = response.statusCode();
+            writeSpan.setAttribute("status_code", statusCode);
+
+            if (statusCode >= 400) {
+                String errorBody = response.bodyAsString();
+                writeSpan.setStatus(StatusCode.ERROR, "HTTP error: " + statusCode);
+                writeSpan.setAttribute("error.message", errorBody);
+            } else {
+                writeSpan.setStatus(StatusCode.OK);
+            }
+            writeSpan.end();
+        });
+    }
+}

--- a/opengemini-client/src/main/java/io/opengemini/client/interceptor/package-info.java
+++ b/opengemini-client/src/main/java/io/opengemini/client/interceptor/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.interceptor;

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
         <maven-scm-provider-gitexe.version>2.1.0</maven-scm-provider-gitexe.version>
         <mockito.version>5.13.0</mockito.version>
         <okhttp.version>4.12.0</okhttp.version>
+        <opentelemetry-exporter.version>1.32.0</opentelemetry-exporter.version>
+        <opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
+        <opentelemetry.version>1.48.0</opentelemetry.version>
         <puppycrawl.version>10.18.1</puppycrawl.version>
         <protobuf.version>3.25.1</protobuf.version>
         <protoc.version>3.25.1</protoc.version>
@@ -102,6 +105,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
                 <version>${grpc.version}</version>
@@ -112,6 +120,26 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <version>${opentelemetry-exporter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry-semconv.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
**What problem does this PR solve?**

 Provides distributed tracing capability for the OpenGemini Java client, enabling users to achieve call chain visualization, performance analysis, and troubleshooting through the OpenTelemetry ecosystem (such as Jaeger), thereby enhancing system observability.
 
**What is changed and how it works?**
 
1.  Added the  Interceptor  interface and  OtelInterceptor  implementation to insert OpenTelemetry tracing logic before and after query (Query) and write (Write) operations, including Span creation, attribute setting, and status marking.

2. Extended the  Query  and  Write  classes by adding a  Map<String, Object>  attribute map to store context information such as tracing Spans.

3. Modified the  OpenGeminiClient  class to introduce an interceptor flow when executing query and write operations, ensuring the tracing logic is triggered.

4. Added the  OpenTelemetryConfig  configuration class and related dependency management to support the configuration and use of Tracer.

 
**How has this been tested?**
 
Configure an OpenTelemetry exporter (Jaeger), execute query and write operations, and verify whether tracing data is generated and reported normally, ensuring that the creation, attributes, and status of Spans meet expectations.
 
**Checklist:**

- [✓ ] My code follows the style guidelines of this project
- [✓ ] have performed a self-review of my own code
- [✓ ] have commented my code, particularly in hard-to-understand areas
- [   ] have made corresponding changes to the documentation
- [✓ ] My changes generate no new warnings
- [   ] have added tests that prove my feature works
- [✓ ] New and existing unit tests pass locally with my changes
- [✓ ] Any dependent changes have been merged and published in downstream modules

*related documents:
https://github.com/openGemini/openGemini.github.io/pull/163