### PR TITLE
feat: switch the otel server for unit test integration

### DIFF
--- a/.github/workflows/java_unit_tests.yml
+++ b/.github/workflows/java_unit_tests.yml
@@ -33,7 +33,13 @@ jobs:
           distribution: 'temurin'
       - name: setup OpenGemini
         uses: hezhangjian/setup-opengemini-action@main
-      - name: unit tests
-        run: mvn -B clean test
+      - name: wait opengemini started
+        run: sleep 5
+      - name: setup go-env
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
       - name: setup ts-trace
         run: go install github.com/openGemini/observability/trace/cmd/ts-trace@latest && ts-trace &
+      - name: unit tests
+        run: mvn -B clean test

--- a/opengemini-client/src/test/java/io/opengemini/client/interceptor/TraceFailureToleranceTest.java
+++ b/opengemini-client/src/test/java/io/opengemini/client/interceptor/TraceFailureToleranceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 openGemini Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opengemini.client.interceptor;
+
+import io.github.openfacade.http.HttpClientConfig;
+import io.opengemini.client.api.Address;
+import io.opengemini.client.api.Configuration;
+import io.opengemini.client.api.Query;
+import io.opengemini.client.api.Write;
+import io.opengemini.client.impl.OpenGeminiClient;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Example demonstrating OpenGemini client usage with interceptors.
+ */
+
+public class TraceFailureToleranceTest {
+
+    private OpenGeminiClient openGeminiClient;
+
+    @BeforeEach
+    void setUp() {
+        HttpClientConfig httpConfig = new HttpClientConfig.Builder()
+                .connectTimeout(Duration.ofSeconds(3))
+                .timeout(Duration.ofSeconds(3))
+                .build();
+        Configuration configuration = Configuration.builder()
+                .addresses(Collections.singletonList(new Address("127.0.0.1", 8086)))
+                .httpConfig(httpConfig)
+                .gzipEnabled(false)
+                .build();
+        this.openGeminiClient = new OpenGeminiClient(configuration);
+
+        OtelInterceptor otelInterceptor = new OtelInterceptor();
+
+        otelInterceptor.setTracer(getErrTracer());
+        openGeminiClient.addInterceptors(otelInterceptor);
+    }
+
+    private Tracer getErrTracer() {
+        OpenTelemetry openTelemetry;
+        OtlpGrpcSpanExporter otlpGrpcSpanExporter = OtlpGrpcSpanExporter.builder()
+                .setEndpoint("http://127.0.0.1:38086")  // error endpoiont to test the failure tolerance
+                .build();
+
+        BatchSpanProcessor spanProcessor = BatchSpanProcessor.builder(otlpGrpcSpanExporter)
+                .setScheduleDelay(100, TimeUnit.MILLISECONDS)
+                .build();
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(spanProcessor)
+                .setResource(Resource.create(
+                        Attributes.of(ResourceAttributes.SERVICE_NAME, "opengemini-client-java")
+                ))
+                .build();
+
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build();
+
+        return openTelemetry.getTracer("opengemini-client-java");
+    }
+
+    @Test
+    void testTracingIntegration() throws ExecutionException, InterruptedException {
+        String databaseTestName = "tracing_test_db";
+        CompletableFuture<Void> createdb = openGeminiClient.createDatabase(databaseTestName);
+        createdb.get();
+
+        Assertions.assertDoesNotThrow(() -> {
+            Write write = new Write(
+                    "tracing_test_db",
+                    "autogen",
+                    "tracing_measurement,tag=test value=8 " + System.currentTimeMillis(),
+                    "ns"
+            );
+
+            openGeminiClient.executeWrite(
+                    write.getDatabase(),
+                    write.getRetentionPolicy(),
+                    write.getLineProtocol()
+            ).get(10, TimeUnit.SECONDS);
+
+            Query query = new Query("SELECT * FROM tracing_measurement");
+            openGeminiClient.query(query).get(10, TimeUnit.SECONDS);
+
+        }, "Tracing integration should not throw an exception");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry-exporter.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
**What problem does this PR solve?**

1. Switched the OTel server: Replaced the Jaeger exporter with an OTLP gRPC exporter, connecting to the local ts-trace service
2. Enhanced trace integration tests: Added a complete trace data verification mechanism
3. Added fault tolerance tests: Introduced trace system failure tolerance tests
4. Improved test workflow: Integrated ts-trace service startup into the CI workflow

**Core Design**

1. Interceptor pattern: Automatically adds tracing logic before and after client operations via OtelInterceptor
2. Asynchronous batch processing: Uses BatchSpanProcessor to improve performance and minimize impact on the main flow
3. Resource cleanup: Automatically cleans up trace data before and after each test case to ensure test isolation

**Key Implementation**

```java
// Trace verification mechanism
private void checkLastTraceCommand(String command) {
    String queryTraceCommand = "SELECT command FROM \"%s\"".formatted(measurementName);
    // Query and verify trace data
}

// Fault tolerance design
private Tracer getErrTracer() {
    // Use an incorrect endpoint to test failure tolerance
    .setEndpoint("http://127.0.0.1:38086")
}
```

**Test Coverage**

-  Basic query operation tracing: Validates tracing for commands like SHOW DATABASES
-  Write operation tracing: Validates tracing for Line Protocol writes
-  Integration tests: Complete tracing for database creation, write, and query workflows
-  Fault tolerance tests: Client behavior when the OTel service is unavailable

**CI Configuration Update**
Automatically starts the ts-trace service before unit tests

```yaml
- name: setup ts-trace
  run: go install github.com/openGemini/observability/trace/cmd/ts-trace@latest && ts-trace &
```

Achieved Results

- [✓ ]  Achieved seamless integration of OpenTelemetry with the OpenGemini client

- [✓ ]  Provided end-to-end trace data verification capability

- [✓ ]  Ensured the client can still function normally when the OTel service is unavailable

- [✓ ]  Improved unit test coverage and reliability

*related documents:
https://github.com/openGemini/openGemini.github.io/pull/163